### PR TITLE
Revert "[develop][FIX][i5439]add certificate number1 url"

### DIFF
--- a/website_certificate/__openerp__.py
+++ b/website_certificate/__openerp__.py
@@ -3,10 +3,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Website Certificate',
-    'version': '8.0.1.0.0',
+    'version': '8.0.0.0.3',
     'category': 'website',
     'depends': ['base', 'website'],
-    'author': 'Elico-Corp',
+    'author': 'Elico-Corp,Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'website': 'https://www.elico-corp.com',
     'images': [],

--- a/website_certificate/certificate.py
+++ b/website_certificate/certificate.py
@@ -8,7 +8,6 @@ class CompanyFiling(models.Model):
     _inherit = 'website'
 
     certificate_number1 = fields.Char(string='Certificate Number1')
-    certificate_number1_url = fields.Char(string='Certificate Number1 URL')
     certificate_url1 = fields.Char(string='Certificate URL1')
     certificate_logo1 = fields.Binary(string='Certificate Logo1')
     certificate_number2 = fields.Char(string='Certificate Number2')
@@ -21,8 +20,6 @@ class CompanyFilingSetting(models.TransientModel):
 
     certificate_number1 = fields.Char(
         string='Certificate Number1', related='website_id.certificate_number1')
-    certificate_number1_url = fields.Char(
-        string='Certificate Number1 URL', related='website_id.certificate_number1_url')
     certificate_url1 = fields.Char(
         string='Certificate URL1', related='website_id.certificate_url1')
     certificate_logo1 = fields.Binary(

--- a/website_certificate/certificate_view.xml
+++ b/website_certificate/certificate_view.xml
@@ -11,10 +11,6 @@
                     <div class="oe_inline">
                         <field name="certificate_number1" placeholder="沪ICP备12005091号"/>
                     </div>
-                    <label for="certificate_number1_url"/>
-                    <div class="oe_inline">
-                        <field name="certificate_number1_url" placeholder="http://www.miitbeian.gov.cn"/>
-                    </div>
                     <label for="certificate_url1"/>
                     <div class="oe_inline">
                         <field name="certificate_url1" placeholder="http://www.sgs.gov.cn/lz/licenseLink.do"/>
@@ -48,9 +44,7 @@
                         <span t-field="website.certificate_logo1"
                               t-field-options='{"widget": "image", "style": "display: inline; vertical-align: baseline;"}'/>
                     </a>
-                    <a t-attf-href="#{website.certificate_number1_url}" target="_blank">
-                        <span t-field="website.certificate_number1"/>
-                    </a>
+                    <span t-field="website.certificate_number1"/>
                 </span>
                 <span>-
                     <a t-attf-href="#{website.certificate_url2}" target="_BLANK">


### PR DESCRIPTION
Reverts Elico-Corp/odoo-addons#230

```
2018-11-22 03:52:42,389 354 INFO DB werkzeug: 192.168.32.1 - - [22/Nov/2018 03:52:42] "POST /calendar/notify HTTP/1.0" 200 -
2018-11-22 03:52:42,438 354 ERROR DB openerp.sql_db: Programming error: column website.certificate_number1_url does not exist
LINE 1: ...T "website"."piwik_analytics_host","website"."id","website"....
                                                             ^
, in query  SELECT "website"."piwik_analytics_host","website"."id","website"."certificate_number1_url","website"."certificate_number1","website"."menu_id","website"."captcha_crypt_password","website"."write_date","website"."social_facebook","website"."create_date","website"."certificate_url1","website"."social_youtube","website"."certificate_number2","website"."social_github","website"."captcha_chars","website"."certificate_url2","website"."piwik_analytics_id","website"."user_id","website"."captcha_length","website"."social_googleplus","website"."default_lang_code","website"."create_uid","website"."social_linkedin","website"."google_analytics_key","website"."company_id","website"."write_uid","website"."social_twitter","website"."name","website"."default_lang_id" FROM "website"
                        WHERE "website".id IN %s  ORDER BY "website"."id"  
                    
2018-11-22 03:52:42,442 354 ERROR DB openerp.addons.website.models.ir_http: 500 Internal Server Error:

Traceback (most recent call last):
  File "/opt/odoo/sources/odoo/addons/website/models/ir_http.py", line 202, in _handle_exception
    response = super(ir_http, self)._handle_exception(exception)
  File "/opt/odoo/sources/odoo/openerp/addons/base/ir/ir_http.py", line 145, in _handle_exception
    return request._handle_exception(exception)
  File "/opt/odoo/sources/odoo/openerp/http.py", line 675, in _handle_exception
    return super(HttpRequest, self)._handle_exception(exception)
  File "/opt/odoo/sources/odoo/openerp/http.py", line 1386, in get_response
    result.flatten()
  File "/opt/odoo/sources/odoo/openerp/http.py", line 1250, in flatten
    self.response.append(self.render())
  File "/opt/odoo/sources/odoo/openerp/http.py", line 1244, in render
    context=request.context)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/addons/website/models/ir_ui_view.py", line 142, in render
    company = self.pool['res.company'].browse(cr, SUPERUSER_ID, request.website.company_id.id, context=context)
  File "/opt/odoo/sources/odoo/openerp/fields.py", line 835, in __get__
    self.determine_value(record)
  File "/opt/odoo/sources/odoo/openerp/fields.py", line 928, in determine_value
    record._prefetch_field(self)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/models.py", line 3243, in _prefetch_field
    result = records.read(list(fnames), load='_classic_write')
  File "/opt/odoo/sources/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/models.py", line 3183, in read
    self._read_from_database(stored, inherited)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/models.py", line 3312, in _read_from_database
    cr.execute(query_str, [tuple(sub_ids)] + where_params)
  File "/opt/odoo/sources/odoo/openerp/sql_db.py", line 171, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/sql_db.py", line 247, in execute
    res = self._obj.execute(query, params)
ProgrammingError: column website.certificate_number1_url does not exist
LINE 1: ...T "website"."piwik_analytics_host","website"."id","website"....
                                                             ^


2018-11-22 03:52:42,444 354 ERROR DB openerp.sql_db: bad query:  SELECT "website"."piwik_analytics_host","website"."id","website"."certificate_number1_url","website"."certificate_number1","website"."menu_id","website"."captcha_crypt_password","website"."write_date","website"."social_facebook","website"."create_date","website"."certificate_url1","website"."social_youtube","website"."certificate_number2","website"."social_github","website"."captcha_chars","website"."certificate_url2","website"."piwik_analytics_id","website"."user_id","website"."captcha_length","website"."social_googleplus","website"."default_lang_code","website"."create_uid","website"."social_linkedin","website"."google_analytics_key","website"."company_id","website"."write_uid","website"."social_twitter","website"."name","website"."default_lang_id" FROM "website"
                        WHERE "website".id IN (1)  ORDER BY "website"."id"  
                    
Traceback (most recent call last):
  File "/opt/odoo/sources/odoo/openerp/sql_db.py", line 247, in execute
    res = self._obj.execute(query, params)
InternalError: current transaction is aborted, commands ignored until end of transaction block

2018-11-22 03:52:42,445 354 ERROR DB openerp.sql_db: bad query:  SELECT "website"."piwik_analytics_host","website"."id","website"."certificate_number1_url","website"."certificate_number1","website"."menu_id","website"."captcha_crypt_password","website"."write_date","website"."social_facebook","website"."create_date","website"."certificate_url1","website"."social_youtube","website"."certificate_number2","website"."social_github","website"."captcha_chars","website"."certificate_url2","website"."piwik_analytics_id","website"."user_id","website"."captcha_length","website"."social_googleplus","website"."default_lang_code","website"."create_uid","website"."social_linkedin","website"."google_analytics_key","website"."company_id","website"."write_uid","website"."social_twitter","website"."name","website"."default_lang_id" FROM "website"
                        WHERE "website".id IN (1)  ORDER BY "website"."id"  
                    
Traceback (most recent call last):
  File "/opt/odoo/sources/odoo/openerp/sql_db.py", line 247, in execute
    res = self._obj.execute(query, params)
InternalError: current transaction is aborted, commands ignored until end of transaction block

2018-11-22 03:52:42,468 354 INFO DB werkzeug: 192.168.32.1 - - [22/Nov/2018 03:52:42] "GET / HTTP/1.0" 500 -
2018-11-22 03:52:42,489 354 ERROR DB werkzeug: Error on request:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 177, in run_wsgi
    execute(self.server.app)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 165, in execute
    application_iter = app(environ, start_response)
  File "/opt/odoo/sources/odoo/openerp/service/server.py", line 294, in app
    return self.app(e, s)
  File "/opt/odoo/sources/odoo/openerp/service/wsgi_server.py", line 216, in application
    return application_unproxied(environ, start_response)
  File "/opt/odoo/sources/odoo/openerp/service/wsgi_server.py", line 202, in application_unproxied
    result = handler(environ, start_response)
  File "/opt/odoo/sources/odoo/openerp/http.py", line 1299, in __call__
    return self.dispatch(environ, start_response)
  File "/opt/odoo/sources/odoo/openerp/http.py", line 1458, in dispatch
    response = self.get_response(httprequest, result, explicit_session)
  File "/opt/odoo/sources/odoo/openerp/http.py", line 1389, in get_response
    result = request.registry['ir.http']._handle_exception(e)
  File "/opt/odoo/sources/odoo/addons/website/models/ir_http.py", line 252, in _handle_exception
    html = request.website._render('website.http_error', values)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 592, in new_api
    result = method(self._model, cr, uid, self.ids, *args, **old_kwargs)
  File "/opt/odoo/sources/odoo/addons/website/models/website.py", line 296, in _render
    return self.pool['ir.ui.view'].render(cr, uid, template, values=values, context=context)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/addons/website/models/ir_ui_view.py", line 142, in render
    company = self.pool['res.company'].browse(cr, SUPERUSER_ID, request.website.company_id.id, context=context)
  File "/opt/odoo/sources/odoo/openerp/fields.py", line 835, in __get__
    self.determine_value(record)
  File "/opt/odoo/sources/odoo/openerp/fields.py", line 928, in determine_value
    record._prefetch_field(self)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/models.py", line 3243, in _prefetch_field
    result = records.read(list(fnames), load='_classic_write')
  File "/opt/odoo/sources/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/models.py", line 3183, in read
    self._read_from_database(stored, inherited)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/models.py", line 3312, in _read_from_database
    cr.execute(query_str, [tuple(sub_ids)] + where_params)
  File "/opt/odoo/sources/odoo/openerp/sql_db.py", line 171, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/sql_db.py", line 247, in execute
    res = self._obj.execute(query, params)
InternalError: current transaction is aborted, commands ignored until end of transaction block
2018-11-22 03:52:42,632 354 ERROR DB openerp.sql_db: Programming error: column website.certificate_number1_url does not exist
LINE 1: ...T "website"."piwik_analytics_host","website"."id","website"....
                                                             ^
, in query  SELECT "website"."piwik_analytics_host","website"."id","website"."certificate_number1_url","website"."certificate_number1","website"."menu_id","website"."captcha_crypt_password","website"."write_date","website"."social_facebook","website"."create_date","website"."certificate_url1","website"."social_youtube","website"."certificate_number2","website"."social_github","website"."captcha_chars","website"."certificate_url2","website"."piwik_analytics_id","website"."user_id","website"."captcha_length","website"."social_googleplus","website"."default_lang_code","website"."create_uid","website"."social_linkedin","website"."google_analytics_key","website"."company_id","website"."write_uid","website"."social_twitter","website"."name","website"."default_lang_id" FROM "website"
                        WHERE "website".id IN %s  ORDER BY "website"."id"  
                    
2018-11-22 03:52:42,634 354 ERROR DB openerp.sql_db: bad query:  SELECT "website"."piwik_analytics_host","website"."id","website"."certificate_number1_url","website"."certificate_number1","website"."menu_id","website"."captcha_crypt_password","website"."write_date","website"."social_facebook","website"."create_date","website"."certificate_url1","website"."social_youtube","website"."certificate_number2","website"."social_github","website"."captcha_chars","website"."certificate_url2","website"."piwik_analytics_id","website"."user_id","website"."captcha_length","website"."social_googleplus","website"."default_lang_code","website"."create_uid","website"."social_linkedin","website"."google_analytics_key","website"."company_id","website"."write_uid","website"."social_twitter","website"."name","website"."default_lang_id" FROM "website"
                        WHERE "website".id IN (1)  ORDER BY "website"."id"  
                    
Traceback (most recent call last):
  File "/opt/odoo/sources/odoo/openerp/sql_db.py", line 247, in execute
    res = self._obj.execute(query, params)
InternalError: current transaction is aborted, commands ignored until end of transaction block

2018-11-22 03:52:42,643 354 INFO DB werkzeug: 192.168.32.1 - - [22/Nov/2018 03:52:42] "GET /favicon.ico HTTP/1.0" 500 -
2018-11-22 03:52:42,665 354 ERROR DB werkzeug: Error on request:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 177, in run_wsgi
    execute(self.server.app)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 165, in execute
    application_iter = app(environ, start_response)
  File "/opt/odoo/sources/odoo/openerp/service/server.py", line 294, in app
    return self.app(e, s)
  File "/opt/odoo/sources/odoo/openerp/service/wsgi_server.py", line 216, in application
    return application_unproxied(environ, start_response)
  File "/opt/odoo/sources/odoo/openerp/service/wsgi_server.py", line 202, in application_unproxied
    result = handler(environ, start_response)
  File "/opt/odoo/sources/odoo/openerp/http.py", line 1299, in __call__
    return self.dispatch(environ, start_response)
  File "/opt/odoo/sources/odoo/openerp/http.py", line 1273, in __call__
    return self.app(environ, start_wrapped)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/wsgi.py", line 588, in __call__
    return self.app(environ, start_response)
  File "/opt/odoo/sources/odoo/openerp/http.py", line 1453, in dispatch
    result = ir_http._dispatch()
  File "/opt/odoo/sources/odoo/addons/crm/ir_http.py", line 13, in _dispatch
    response = super(ir_http, self)._dispatch()
  File "/opt/odoo/sources/odoo/addons/website/models/ir_http.py", line 149, in _dispatch
    resp = super(ir_http, self)._dispatch()
  File "/opt/odoo/sources/odoo/openerp/addons/base/ir/ir_http.py", line 155, in _dispatch
    return self._handle_exception(e)
  File "/opt/odoo/sources/odoo/addons/website/models/ir_http.py", line 252, in _handle_exception
    html = request.website._render('website.http_error', values)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 592, in new_api
    result = method(self._model, cr, uid, self.ids, *args, **old_kwargs)
  File "/opt/odoo/sources/odoo/addons/website/models/website.py", line 296, in _render
    return self.pool['ir.ui.view'].render(cr, uid, template, values=values, context=context)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/addons/website/models/ir_ui_view.py", line 142, in render
    company = self.pool['res.company'].browse(cr, SUPERUSER_ID, request.website.company_id.id, context=context)
  File "/opt/odoo/sources/odoo/openerp/fields.py", line 835, in __get__
    self.determine_value(record)
  File "/opt/odoo/sources/odoo/openerp/fields.py", line 928, in determine_value
    record._prefetch_field(self)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/models.py", line 3243, in _prefetch_field
    result = records.read(list(fnames), load='_classic_write')
  File "/opt/odoo/sources/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/models.py", line 3183, in read
    self._read_from_database(stored, inherited)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/models.py", line 3312, in _read_from_database
    cr.execute(query_str, [tuple(sub_ids)] + where_params)
  File "/opt/odoo/sources/odoo/openerp/sql_db.py", line 171, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/sql_db.py", line 247, in execute
    res = self._obj.execute(query, params)
InternalError: current transaction is aborted, commands ignored until end of transaction block
2018-11-22 03:52:50,381 354 INFO DB werkzeug: 192.168.32.1 - - [22/Nov/2018 03:52:50] "POST /calendar/notify HTTP/1.0" 200 -
2018-11-22 03:52:54,977 354 INFO DB werkzeug: 192.168.32.1 - - [22/Nov/2018 03:52:54] "POST /calendar/notify HTTP/1.0" 200 -
2018-11-22 03:52:57,050 354 INFO DB werkzeug: 192.168.32.1 - - [22/Nov/2018 03:52:57] "POST /calendar/notify HTTP/1.0" 200 -
2018-11-22 03:53:03,264 354 INFO DB werkzeug: 192.168.32.1 - - [22/Nov/2018 03:53:03] "POST /calendar/notify HTTP/1.0" 200 -
2018-11-22 03:53:07,124 354 ERROR DB openerp.sql_db: Programming error: column website.certificate_number1_url does not exist
LINE 1: ...T "website"."piwik_analytics_host","website"."id","website"....
                                                             ^
, in query  SELECT "website"."piwik_analytics_host","website"."id","website"."certificate_number1_url","website"."certificate_number1","website"."menu_id","website"."captcha_crypt_password","website"."write_date","website"."social_facebook","website"."create_date","website"."certificate_url1","website"."social_youtube","website"."certificate_number2","website"."social_github","website"."captcha_chars","website"."certificate_url2","website"."piwik_analytics_id","website"."user_id","website"."captcha_length","website"."social_googleplus","website"."default_lang_code","website"."create_uid","website"."social_linkedin","website"."google_analytics_key","website"."company_id","website"."write_uid","website"."social_twitter","website"."name","website"."default_lang_id" FROM "website"
                        WHERE "website".id IN %s  ORDER BY "website"."id"  
                    
2018-11-22 03:53:07,131 354 INFO DB werkzeug: 192.168.32.1 - - [22/Nov/2018 03:53:07] "GET /blog/our-news-1/post/elico-corp-to-implement-openerp-in-servair-macau-74 HTTP/1.0" 500 -
2018-11-22 03:53:07,147 354 ERROR DB werkzeug: Error on request:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 177, in run_wsgi
    execute(self.server.app)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 165, in execute
    application_iter = app(environ, start_response)
  File "/opt/odoo/sources/odoo/openerp/service/server.py", line 294, in app
    return self.app(e, s)
  File "/opt/odoo/sources/odoo/openerp/service/wsgi_server.py", line 216, in application
    return application_unproxied(environ, start_response)
  File "/opt/odoo/sources/odoo/openerp/service/wsgi_server.py", line 202, in application_unproxied
    result = handler(environ, start_response)
  File "/opt/odoo/sources/odoo/openerp/http.py", line 1299, in __call__
    return self.dispatch(environ, start_response)
  File "/opt/odoo/sources/odoo/openerp/http.py", line 1273, in __call__
    return self.app(environ, start_wrapped)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/wsgi.py", line 588, in __call__
    return self.app(environ, start_response)
  File "/opt/odoo/sources/odoo/openerp/http.py", line 1453, in dispatch
    result = ir_http._dispatch()
  File "/opt/odoo/sources/odoo/addons/crm/ir_http.py", line 13, in _dispatch
    response = super(ir_http, self)._dispatch()
  File "/opt/odoo/sources/odoo/addons/website/models/ir_http.py", line 132, in _dispatch
    or (not url_lang and request.website_multilang and request.lang != request.website.default_lang_code)
  File "/opt/odoo/sources/odoo/openerp/fields.py", line 835, in __get__
    self.determine_value(record)
  File "/opt/odoo/sources/odoo/openerp/fields.py", line 928, in determine_value
    record._prefetch_field(self)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/models.py", line 3243, in _prefetch_field
    result = records.read(list(fnames), load='_classic_write')
  File "/opt/odoo/sources/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/models.py", line 3183, in read
    self._read_from_database(stored, inherited)
  File "/opt/odoo/sources/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/models.py", line 3312, in _read_from_database
    cr.execute(query_str, [tuple(sub_ids)] + where_params)
  File "/opt/odoo/sources/odoo/openerp/sql_db.py", line 171, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/odoo/sources/odoo/openerp/sql_db.py", line 247, in execute
    res = self._obj.execute(query, params)
ProgrammingError: column website.certificate_number1_url does not exist
LINE 1: ...T "website"."piwik_analytics_host","website"."id","website"....
```