### PR TITLE
8.0 fix web list view sequence

### DIFF
--- a/web_list_view_sequence/static/src/xml/sequence.xml
+++ b/web_list_view_sequence/static/src/xml/sequence.xml
@@ -8,6 +8,38 @@
         <t t-jquery=".oe_list_footer" t-operation="before">
             <th width="20px"></th>
         </t>
+        <t t-jquery="thead" t-operation="replace">
+            <thead>
+                <tr t-if="(!!options.action_buttons and !options.$buttons) or (!!options.pager and !options.$pager)">
+                    <th t-att-colspan="columns_count">
+                        <div class="oe_list_buttons"/>
+                        <div class="oe_list_sidebar"/>
+                        <div class="oe_list_pager"/>
+                    </th>
+                </tr>
+                <tr t-if="options.header" class="oe_list_header_columns">
+                    <t t-foreach="columns" t-as="column">
+                        <th t-if="column.meta">
+                            <t t-esc="column.string"/>
+                        </th>
+                    </t>
+                    <th t-if="options.selectable" width="1">
+                        <input type="checkbox" class="oe_list_record_selector"/>
+                        <th width="1"></th>
+                    </th>
+                    <th t-if="!options.selectable" width="1">
+                        <input type="hidden" class="oe_list_record_selector"/>
+                    </th>
+                    <t t-foreach="columns" t-as="column">
+                        <th t-if="!column.meta and column.invisible !== '1'" t-att-data-id="column.id"
+                            t-attf-class="oe_list_header_#{column.widget or column.type} #{((options.sortable and column.tag !== 'button') ? 'oe_sortable' : null)}"><div>
+                            <t t-if="column.tag !== 'button'"><t t-esc="column.string"/></t>
+                        </div></th>
+                    </t>
+                    <th t-if="options.deletable" class="oe_list_record_delete" width="13px"/>
+                </tr>
+            </thead>
+        </t>
     </t>
 
     <t t-extend="ListView.rows">

--- a/web_list_view_sequence/static/src/xml/sequence.xml
+++ b/web_list_view_sequence/static/src/xml/sequence.xml
@@ -14,14 +14,14 @@
         <t t-jquery="t:first" t-operation="replace">
             <t t-call="ListView.row">
                 <t t-set="record" t-value="records.at(index)"/>
-                <t t-set="sequence" t-value="records.indexOf(record) + 1"/>
+                <t t-if="records" t-set="record.attributes.row_n" t-value="records.indexOf(record) + 1"/>
             </t>
         </t>
     </t>
 
     <t t-extend="ListView.row">
         <t t-jquery=".oe_list_record_selector" t-operation="after">
-            <td><t t-esc="sequence"/></td>
+            <td><t t-esc="record.attributes.row_n"/></td>
         </t>
     </t>
 


### PR DESCRIPTION
Steps to reproduce: Choose a Many2one field in a form in edit mode, and then select the "Search more" option. When the search view opens, column headers are not well displayed, and rownumber is in under the label of the first field, and first field data is under second field label, and so on.
This fix solves this issue.